### PR TITLE
feat: support absolute paths in worktree_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,17 @@ scripts/dev-secrets.sh
 Absolute paths and parent-traversal entries (`../...`) are rejected to keep copies confined to the worktree. The setting key `worktreeinclude_file` lets you change the filename.
 
 **Worktree Organization:**
-- **`worktree_dir = ".worktrees"`**: Configures the directory name where all worktrees are aggregated
-- **Centralized location**: All worktrees are organized in one place within your repository
-- **Customizable**: Change the directory name to suit your preferences (e.g., `_worktrees`, `.wt`, etc.)
+- **`worktree_dir = ".worktrees"`**: Configures where all worktrees are aggregated.
+- **Relative path** (default): Resolved against the repository root, so each repo keeps its own `.worktrees/<branch>` directory.
+- **Absolute path** (`/...` or `~/...`): Used as a shared base directory. Worktrees are namespaced by repo name to avoid collisions across repositories: `<absolute-base>/<repo-name>/<branch>`.
+
+```lua
+-- Per-repo (default): <repo>/.worktrees/<branch>
+require('git_worktree').setup({ worktree_dir = ".worktrees" })
+
+-- Shared across repos: ~/.git_worktrees/<repo>/<branch>
+require('git_worktree').setup({ worktree_dir = "~/.git_worktrees" })
+```
 
 **Example:** If you have `A/init.lua` open and switch worktrees, the buffer automatically updates to point to the same file in the new worktree location.
 

--- a/lua/git_worktree/init.lua
+++ b/lua/git_worktree/init.lua
@@ -72,15 +72,38 @@ local function validate_branch_name(branch)
   return true, nil
 end
 
+local function is_absolute_path(path)
+  -- Treat both POSIX absolute paths ("/...") and "~"-prefixed paths as absolute
+  -- since the user's intent in both cases is "outside the repo".
+  return path:sub(1, 1) == "/" or path:sub(1, 1) == "~"
+end
+
+local function resolve_worktree_base(git_root)
+  local config_dir = M.config.worktree_dir or ".worktrees"
+
+  if is_absolute_path(config_dir) then
+    -- Absolute base: namespace by repo name so a single shared directory
+    -- (e.g. "~/.git_worktrees") can hold worktrees from many repos without
+    -- branch-name collisions.
+    local expanded = vim.fn.expand(config_dir)
+    local repo_name = git_root:match("([^/]+)/?$") or "repo"
+    return expanded .. "/" .. repo_name
+  end
+
+  return git_root .. "/" .. config_dir
+end
+
 local function ensure_worktree_directory(git_root)
-  local worktree_dir = git_root .. "/" .. M.config.worktree_dir
+  local worktree_dir = resolve_worktree_base(git_root)
   local stat = vim.loop.fs_stat(worktree_dir)
 
   if not stat then
-    -- Create the worktree aggregate directory
-    local success, err_name, err_msg = vim.loop.fs_mkdir(worktree_dir, 511)  -- 511 in decimal = 777 in octal
-    if not success then
-      return nil, "Failed to create worktree directory: " .. (err_msg or err_name or "Unknown error")
+    -- Use mkdir -p semantics: an absolute base may need several intermediate
+    -- directories (e.g. "~/.git_worktrees/<repo>"), and the relative case
+    -- previously only created a single level.
+    local ok = pcall(vim.fn.mkdir, worktree_dir, "p")
+    if not ok or not vim.loop.fs_stat(worktree_dir) then
+      return nil, "Failed to create worktree directory: " .. worktree_dir
     end
   end
 

--- a/tests/git_worktree_spec.lua
+++ b/tests/git_worktree_spec.lua
@@ -289,6 +289,108 @@ describe("git_worktree", function()
     end)
   end)
 
+  describe("worktree_dir with absolute path", function()
+    local test_branch = "test/abs-path"
+    -- Resolve /tmp through fs_realpath because macOS symlinks /tmp -> /private/tmp,
+    -- and getcwd() returns the realpath form after `cd`.
+    local tmp_real = vim.loop.fs_realpath("/tmp") or "/tmp"
+    local abs_base = tmp_real .. "/git_worktree_abs_test_" .. tostring(vim.fn.getpid())
+    local created_path
+
+    before_each(function()
+      created_path = nil
+      vim.fn.delete(abs_base, "rf")
+      git_worktree.setup({
+        cleanup_buffers = true,
+        warn_unsaved = true,
+        update_buffers = true,
+        worktree_dir = abs_base,
+      })
+    end)
+
+    after_each(function()
+      vim.cmd("cd " .. original_cwd)
+      if created_path then
+        vim.fn.system("git worktree remove --force " .. created_path)
+      end
+      vim.fn.system("git branch -D " .. test_branch)
+      vim.fn.delete(abs_base, "rf")
+      git_worktree.setup({
+        cleanup_buffers = true,
+        warn_unsaved = true,
+        update_buffers = true,
+        worktree_dir = ".worktrees",
+      })
+    end)
+
+    it("creates worktree under absolute base, namespaced by repo", function()
+      local success, err = git_worktree.create_worktree(test_branch, {})
+      assert.is_true(success, err)
+
+      created_path = vim.fn.getcwd()
+      assert.is_truthy(
+        created_path:find("^" .. vim.pesc(abs_base) .. "/"),
+        "worktree path " .. created_path .. " should be under " .. abs_base
+      )
+      -- Branch slashes become underscores in the directory leaf
+      assert.is_truthy(
+        created_path:match("/test_abs%-path$"),
+        "worktree leaf should be slashified branch name, got: " .. created_path
+      )
+      -- One namespace level should exist between abs_base and the branch leaf
+      local relative = created_path:sub(#abs_base + 2)
+      assert.is_truthy(
+        relative:match("^[^/]+/test_abs%-path$"),
+        "expected <repo>/<branch> layout, got: " .. relative
+      )
+    end)
+  end)
+
+  describe("worktree_dir with ~ expansion", function()
+    local test_branch = "test/abs-tilde"
+    local pid = tostring(vim.fn.getpid())
+    local rel_home = ".git_worktree_test_tilde_" .. pid
+    local home_dir = vim.fn.expand("~/" .. rel_home)
+    local created_path
+
+    before_each(function()
+      created_path = nil
+      vim.fn.delete(home_dir, "rf")
+      git_worktree.setup({
+        cleanup_buffers = true,
+        warn_unsaved = true,
+        update_buffers = true,
+        worktree_dir = "~/" .. rel_home,
+      })
+    end)
+
+    after_each(function()
+      vim.cmd("cd " .. original_cwd)
+      if created_path then
+        vim.fn.system("git worktree remove --force " .. created_path)
+      end
+      vim.fn.system("git branch -D " .. test_branch)
+      vim.fn.delete(home_dir, "rf")
+      git_worktree.setup({
+        cleanup_buffers = true,
+        warn_unsaved = true,
+        update_buffers = true,
+        worktree_dir = ".worktrees",
+      })
+    end)
+
+    it("expands ~ in worktree_dir", function()
+      local success, err = git_worktree.create_worktree(test_branch, {})
+      assert.is_true(success, err)
+
+      created_path = vim.fn.getcwd()
+      assert.is_truthy(
+        created_path:find("^" .. vim.pesc(home_dir) .. "/"),
+        "worktree path " .. created_path .. " should be under " .. home_dir
+      )
+    end)
+  end)
+
   describe("command execution", function()
     local test_branch = "test/commands"
 


### PR DESCRIPTION
## Summary
- Treat a `worktree_dir` starting with `/` or `~` as an absolute *base* directory shared across repos, with each repo's worktrees namespaced as `<base>/<repo>/<branch>` to avoid branch-name collisions.
- Expand `~` via `vim.fn.expand` and create nested base directories with `mkdir -p` semantics (the previous `fs_mkdir` only created a single level).
- Document the relative vs. absolute behavior in the README and add tests covering both the absolute-path and `~`-expansion cases.

## Test plan
- [ ] `nvim --headless -c "PlenaryBustedDirectory tests/"` passes, including the two new specs (`worktree_dir with absolute path`, `worktree_dir with ~ expansion`).
- [ ] With `worktree_dir = "~/.git_worktrees"`, creating a worktree lands at `~/.git_worktrees/<repo>/<branch>` and switching/cleanup still work.
- [ ] With the default `worktree_dir = ".worktrees"`, behavior is unchanged (worktrees still created under `<repo>/.worktrees/<branch>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)