### PR TITLE
fix: fetch latest origin/<default> when creating worktree from default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ The plugin automatically detects the default branch by:
 2. Querying `git remote show origin` for the HEAD branch
 3. Falling back to common defaults (`main`, `master`)
 
+When `origin/<default>` exists, the plugin runs `git fetch origin <default>` before creating the worktree and bases the new branch on the freshly-fetched `origin/<default>` (with `--no-track`, so the new feature branch does not start tracking the default branch). This guarantees the worktree starts from the latest upstream tip even when the local default branch hasn't been pulled. If the fetch fails (offline, no origin), the plugin falls back to the local default branch and prints a warning.
+
 ## GitHub PR Review
 
 The `:GitWorktreeReview` command streamlines code review by automatically:

--- a/lua/git_worktree/init.lua
+++ b/lua/git_worktree/init.lua
@@ -499,21 +499,47 @@ function M.create_worktree(branch, opts)
   else
     -- Branch doesn't exist, determine base branch
     local base_branch
+    local no_track = false
     if opts.from_default_branch then
-      -- Create from default branch
+      -- Prefer the freshly-fetched origin tip so the new worktree starts from
+      -- the up-to-date upstream rather than a stale local copy of the default
+      -- branch.
       local default_branch, default_err = get_default_branch()
       if default_err then
         return false, default_err
       end
-      base_branch = default_branch
-      print("Creating new branch '" .. branch .. "' and worktree from default branch '" .. base_branch .. "'...")
+
+      local _, origin_ref_err = execute_command(
+        "git show-ref --verify --quiet refs/remotes/origin/" .. default_branch)
+      local has_origin_ref = origin_ref_err == nil
+
+      if has_origin_ref then
+        print("Fetching latest origin/" .. default_branch .. "...")
+        local _, fetch_err = execute_command(
+          "git fetch --quiet origin " .. default_branch)
+        if fetch_err then
+          print("Warning: fetch failed, falling back to local '"
+            .. default_branch .. "': " .. fetch_err)
+          base_branch = default_branch
+        else
+          base_branch = "origin/" .. default_branch
+          no_track = true
+        end
+      else
+        base_branch = default_branch
+      end
+
+      print("Creating new branch '" .. branch
+        .. "' and worktree from default branch '" .. base_branch .. "'...")
     else
       -- Create from current HEAD (default behavior)
       print("Creating new branch '" .. branch .. "' and worktree from current HEAD...")
     end
 
     if base_branch then
-      worktree_cmd = "git worktree add " .. quoted_path .. " -b " .. branch .. " " .. base_branch
+      local track_flag = no_track and " --no-track" or ""
+      worktree_cmd = "git worktree add " .. quoted_path
+        .. " -b " .. branch .. track_flag .. " " .. base_branch
     else
       worktree_cmd = "git worktree add " .. quoted_path .. " -b " .. branch
     end


### PR DESCRIPTION
## Summary
- `:GitWorktreeCreate --from-default <branch>` (and `create_worktree(..., { from_default_branch = true })`) was basing the new worktree on the **local** default branch, so a stale local `main` produced a stale starting point.
- Now runs `git fetch --quiet origin <default>` first and bases the new branch on `origin/<default>` with `--no-track`, so the worktree starts from the latest upstream tip without making the new feature branch track the default branch.
- Falls back silently to the local default branch when there is no `origin/<default>` ref, and prints a warning (without aborting) if the fetch itself fails.

## Test plan
- [x] `make test` — same result before and after (15 pass / 4 pre-existing `test/include` failures unrelated to this change)
- [x] Manual smoke test with a bare remote + two clones, simulating a stale local `origin/main`:
  - new branch is created at the freshly fetched remote tip, not the stale local one
  - local `main` is left alone (no implicit fast-forward)
  - new branch has no upstream tracking (`--no-track` honored)
- [x] Manual smoke test with no `origin` remote — falls back to local default, no fetch attempted, no warning noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)