### PR TITLE
fix: accept SSH host aliases and GHE hosts in remote URL parser (#14)

### DIFF
--- a/lua/git_worktree/init.lua
+++ b/lua/git_worktree/init.lua
@@ -292,6 +292,38 @@ local function copy_worktree_includes(source_dir, target_dir)
   return true, nil
 end
 
+-- Parse a GitHub-like remote URL into (owner, repo). The host is intentionally
+-- not pinned to "github.com" so SSH config host aliases (e.g.
+-- "git@github-personal:owner/repo", see ~/.ssh/config) and GitHub Enterprise
+-- hosts both work. The actual API call is delegated to `gh`, which resolves
+-- aliases and honors `GH_HOST` itself.
+local function parse_github_remote_url(url)
+  if not url or url == "" then
+    return nil, nil
+  end
+
+  -- Strip a trailing ".git" so repo names that themselves contain dots
+  -- (e.g. "git_worktree.nvim") survive parsing intact.
+  url = url:gsub("%.git%s*$", ""):gsub("%s+$", "")
+
+  -- scp-like SSH form: [user@]host:owner/repo  (host may be an ssh_config alias)
+  local owner, repo = url:match("^[^@/:]+@[^:/]+:([^/]+)/(.+)$")
+  if owner and repo then
+    return owner, repo
+  end
+
+  -- ssh:// or https:// form: scheme://[user@]host[:port]/owner/repo
+  owner, repo = url:match("^%w[%w+%-.]*://[^/]+/([^/]+)/(.+)$")
+  if owner and repo then
+    return owner, repo
+  end
+
+  return nil, nil
+end
+
+-- Exposed for tests; not part of the public API.
+M._parse_github_remote_url = parse_github_remote_url
+
 local function get_github_remote_info()
   -- Get the remote URL for origin
   local result, err = execute_command("git remote get-url origin")
@@ -299,16 +331,7 @@ local function get_github_remote_info()
     return nil, nil, "No origin remote found"
   end
 
-  -- Strip an optional trailing ".git" so repo names that themselves contain
-  -- dots (e.g. "git_worktree.nvim") survive parsing intact.
-  local url = result:gsub("%.git%s*$", ""):gsub("%s+$", "")
-
-  -- SSH (git@github.com:owner/repo) or HTTPS (https://github.com/owner/repo).
-  local owner, repo = url:match("git@github%.com:([^/]+)/(.+)$")
-  if not owner then
-    owner, repo = url:match("https?://github%.com/([^/]+)/(.+)$")
-  end
-
+  local owner, repo = parse_github_remote_url(result)
   if not owner or not repo then
     return nil, nil, "Could not parse GitHub repository from remote URL"
   end

--- a/tests/git_worktree_spec.lua
+++ b/tests/git_worktree_spec.lua
@@ -342,4 +342,63 @@ describe("git_worktree", function()
       assert.equals("echo 'second'", executed_commands[2])
     end)
   end)
+
+  describe("parse_github_remote_url", function()
+    local parse = git_worktree._parse_github_remote_url
+
+    it("parses SSH form on github.com", function()
+      local owner, repo = parse("git@github.com:owner/repo.git")
+      assert.equals("owner", owner)
+      assert.equals("repo", repo)
+    end)
+
+    it("parses SSH form with a host alias (issue #14)", function()
+      -- e.g. ~/.ssh/config: Host github-personal -> HostName github.com
+      local owner, repo = parse("git@github-personal:owner/repo.git")
+      assert.equals("owner", owner)
+      assert.equals("repo", repo)
+    end)
+
+    it("parses HTTPS form on github.com", function()
+      local owner, repo = parse("https://github.com/owner/repo.git")
+      assert.equals("owner", owner)
+      assert.equals("repo", repo)
+    end)
+
+    it("parses HTTPS form on a custom host (GHE)", function()
+      local owner, repo = parse("https://github.example.com/owner/repo.git")
+      assert.equals("owner", owner)
+      assert.equals("repo", repo)
+    end)
+
+    it("parses ssh:// scheme form", function()
+      local owner, repo = parse("ssh://git@github.com/owner/repo.git")
+      assert.equals("owner", owner)
+      assert.equals("repo", repo)
+    end)
+
+    it("preserves dots inside the repository name", function()
+      local owner, repo = parse("git@github.com:mitubaEX/git_worktree.nvim.git")
+      assert.equals("mitubaEX", owner)
+      assert.equals("git_worktree.nvim", repo)
+    end)
+
+    it("tolerates URLs without a trailing .git", function()
+      local owner, repo = parse("git@github-work:acme/widget")
+      assert.equals("acme", owner)
+      assert.equals("widget", repo)
+    end)
+
+    it("returns nil for unrecognized URLs", function()
+      local owner, repo = parse("not a url")
+      assert.is_nil(owner)
+      assert.is_nil(repo)
+    end)
+
+    it("returns nil for empty input", function()
+      local owner, repo = parse("")
+      assert.is_nil(owner)
+      assert.is_nil(repo)
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary
Fixes #14. `:GitWorktreeReview` errored with `Could not parse GitHub repository from remote URL` whenever the `origin` remote used an SSH config host alias (e.g. `git@github-personal:owner/repo`) or a GitHub Enterprise hostname, because the parser hard-coded `github.com`.

## Changes
- **`lua/git_worktree/init.lua`** — split URL parsing out into `parse_github_remote_url(url)` and relax the patterns:
  - scp-like SSH form: `^[^@/:]+@[^:/]+:owner/repo`
  - scheme form (now also matches `ssh://`): `^scheme://host/owner/repo`
  - trailing `.git` stripping centralized inside the parser, so dotted repo names like `git_worktree.nvim` keep working.
  - exposed as `M._parse_github_remote_url` for tests (commented as not part of the public API).
- **`tests/git_worktree_spec.lua`** — added a `parse_github_remote_url` describe with 9 cases: github.com SSH/HTTPS, host alias (issue #14 repro), GHE-style HTTPS, `ssh://`, dotted repo name, missing `.git`, garbage input, empty string.

The actual API call is still delegated to `gh`, which resolves ssh_config aliases via `HostName` and honors `GH_HOST` for GHE, so no further plumbing is needed for the happy path.

## Tests
`make test` — 28/28 pass (existing 19 + new 9).

## Out of scope
The fork-PR code path adds the fork remote with `https://github.com/...` hard-coded. For SSH-alias users whose `HostName` is `github.com` this still works, and full GHE fork-PR support is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)