### PR TITLE
feat: make gh command configurable via gh_cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ require('git_worktree').setup({
   update_buffers = true,   -- Update buffer paths to match new worktree
   copy_envrc = true,       -- Copy .envrc file to new worktrees (direnv)
   worktree_dir = ".worktrees", -- Directory name for aggregating worktrees
+  gh_cmd = "gh",           -- Command used to invoke the GitHub CLI (PR review)
 })
 ```
 
@@ -162,6 +163,11 @@ require('git_worktree').setup({
 - **`worktree_dir = ".worktrees"`**: Configures the directory name where all worktrees are aggregated
 - **Centralized location**: All worktrees are organized in one place within your repository
 - **Customizable**: Change the directory name to suit your preferences (e.g., `_worktrees`, `.wt`, etc.)
+
+**GitHub CLI Command:**
+- **`gh_cmd = "gh"`**: The command used to invoke the GitHub CLI when fetching PR info for `:GitWorktreeReview`
+- **Wrapper support**: Point it at your own wrapper (e.g. `gh_cmd = "my-gh-wrapper"`) or add flags (e.g. `gh_cmd = "gh --foo"`) when plain `gh` does not work in your environment
+- The command is invoked as `<gh_cmd> pr view <pr_number> --repo <owner>/<repo> --json ...`
 
 **Example:** If you have `A/init.lua` open and switch worktrees, the buffer automatically updates to point to the same file in the new worktree location.
 
@@ -216,6 +222,8 @@ The `:GitWorktreeReview` command streamlines code review by automatically:
 **Requirements for PR review:**
 - GitHub CLI (`gh`) installed and authenticated
 - Repository must have GitHub origin remote
+
+> **Using a `gh` wrapper?** If you wrap or alias `gh` (for custom auth, etc.), set `gh_cmd` in `setup()` so the plugin invokes your command instead of the bare `gh` binary.
 
 ## Bulk Cleanup
 

--- a/lua/git_worktree/init.lua
+++ b/lua/git_worktree/init.lua
@@ -7,6 +7,7 @@ M.config = {
   update_buffers = true,   -- Update buffer paths to match new worktree
   copy_envrc = true,       -- Copy .envrc file to new worktrees (for direnv)
   worktree_dir = ".worktrees", -- Directory name for aggregating worktrees
+  gh_cmd = "gh",           -- Command used to invoke the GitHub CLI; override to use a `gh` wrapper
 }
 
 local function execute_command(cmd)
@@ -233,16 +234,28 @@ local function get_github_remote_info()
   return owner, repo, nil
 end
 
+-- Build the GitHub CLI command used to fetch PR information.
+-- Exposed (and reads M.config.gh_cmd) so users can swap in a `gh` wrapper.
+function M.build_pr_view_command(pr_number, owner, repo)
+  return string.format(
+    "%s pr view %s --repo %s/%s --json headRefName,headRepository",
+    M.config.gh_cmd,
+    pr_number,
+    owner,
+    repo
+  )
+end
+
 local function fetch_pr_info(pr_number)
   -- Get GitHub repository info
   local owner, repo, err = get_github_remote_info()
   if err then
     return nil, err
   end
-  
+
   -- Use GitHub CLI to get PR information
-  local gh_cmd = string.format("gh pr view %s --repo %s/%s --json headRefName,headRepository", pr_number, owner, repo)
-  local result, cmd_err = execute_command(gh_cmd)
+  local pr_view_cmd = M.build_pr_view_command(pr_number, owner, repo)
+  local result, cmd_err = execute_command(pr_view_cmd)
   if cmd_err then
     return nil, "Failed to fetch PR info. Make sure 'gh' CLI is installed and authenticated: " .. cmd_err
   end

--- a/tests/git_worktree_spec.lua
+++ b/tests/git_worktree_spec.lua
@@ -27,6 +27,43 @@ describe("git_worktree", function()
       assert.equals(true, git_worktree.config.cleanup_buffers)
       assert.equals(".worktrees", git_worktree.config.worktree_dir)
     end)
+
+    it("defaults gh_cmd to 'gh'", function()
+      assert.equals("gh", git_worktree.config.gh_cmd)
+    end)
+  end)
+
+  describe("build_pr_view_command", function()
+    -- Restore the default gh command so later tests are unaffected.
+    after_each(function()
+      git_worktree.setup({ gh_cmd = "gh" })
+    end)
+
+    it("builds the PR view command using the configured gh_cmd", function()
+      local cases = {
+        {
+          name = "default gh",
+          gh_cmd = "gh",
+          expected = "gh pr view 16 --repo owner/repo --json headRefName,headRepository",
+        },
+        {
+          name = "wrapper binary",
+          gh_cmd = "my-gh-wrapper",
+          expected = "my-gh-wrapper pr view 16 --repo owner/repo --json headRefName,headRepository",
+        },
+        {
+          name = "command with extra flags",
+          gh_cmd = "gh --foo",
+          expected = "gh --foo pr view 16 --repo owner/repo --json headRefName,headRepository",
+        },
+      }
+
+      for _, case in ipairs(cases) do
+        git_worktree.setup({ gh_cmd = case.gh_cmd })
+        local cmd = git_worktree.build_pr_view_command(16, "owner", "repo")
+        assert.equals(case.expected, cmd, case.name)
+      end
+    end)
   end)
 
   describe("current_worktree", function()


### PR DESCRIPTION
  Allow overriding the GitHub CLI command used by :GitWorktreeReview via
  config.gh_cmd, so users with a `gh` wrapper can fetch PR info. Closes #16.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>